### PR TITLE
fix compilation issue

### DIFF
--- a/xasm.d
+++ b/xasm.d
@@ -2652,12 +2652,12 @@ debug ubyte[] testInstruction(string l) {
 }
 
 unittest {
-	assert(testInstruction("nop") == cast(ubyte[]) x"ea");
-	assert(testInstruction("add (5,0)") == cast(ubyte[]) x"18a2006105");
-	assert(testInstruction("mwa #$abcd $1234") == cast(ubyte[]) x"a9cd8d3412a9ab8d3512");
-	assert(testInstruction("dta 5,d'Foo'*,a($4589)") == cast(ubyte[]) x"05a6efef8945");
+	assert(testInstruction("nop") == cast(ubyte[]) std.conv.hexString!"ea");
+	assert(testInstruction("add (5,0)") == cast(ubyte[]) std.conv.hexString!"18a2006105");
+	assert(testInstruction("mwa #$abcd $1234") == cast(ubyte[]) std.conv.hexString!"a9cd8d3412a9ab8d3512");
+	assert(testInstruction("dta 5,d'Foo'*,a($4589)") == cast(ubyte[]) std.conv.hexString!"05a6efef8945");
 	assert(testInstruction("dta r(1,12,123,1234567890,12345678900000,.5,.03,000.1664534589,1e97)")
-	 == cast(ubyte[]) x"400100000000 401200000000 410123000000 441234567890 461234567890 3f5000000000 3f0300000000 3f1664534589 701000000000");
+	 == cast(ubyte[]) std.conv.hexString!"400100000000 401200000000 410123000000 441234567890 461234567890 3f5000000000 3f0300000000 3f1664534589 701000000000");
 }
 
 void assemblyPair() {


### PR DESCRIPTION
Hello @pfusik ,

This patch can fix some compilation issue :

fix :
```
xasm.d(2655): Error: Built-in hex string literals are obsolete, use std.conv.hexString!"ea" instead.
xasm.d(2656): Error: Built-in hex string literals are obsolete, use std.conv.hexString!"18a2006105" instead.
xasm.d(2657): Error: Built-in hex string literals are obsolete, use std.conv.hexString!"a9cd8d3412a9ab8d3512" instead.
xasm.d(2658): Error: Built-in hex string literals are obsolete, use std.conv.hexString!"05a6efef8945" instead.
xasm.d(2660): Error: Built-in hex string literals are obsolete, use std.conv.hexString!"400100000000 401200000000 410123000000 441234567890 461234567890 3f5000000000 3f0300000000 3f1664534589 701000000000" instead.
```

Regards,