### PR TITLE
WIP: weird hcasm features

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -2536,6 +2536,9 @@ void assemblyInstruction(string instruction) {
 	case "REQ":
 		assemblyRepeat(0xf0);
 		break;
+	case "RLA":
+		putByte(0x2a);
+		break;
 	case "RMI":
 		assemblyRepeat(0x30);
 		break;
@@ -2550,6 +2553,9 @@ void assemblyInstruction(string instruction) {
 		break;
 	case "RPL":
 		assemblyRepeat(0x10);
+		break;
+	case "RRA":
+		putByte(0x6a);
 		break;
 	case "RTI":
 		putByte(0x40);
@@ -2587,6 +2593,9 @@ void assemblyInstruction(string instruction) {
 	case "SEQ":
 		assemblySkip(0xf0);
 		break;
+	case "SLA":
+		putByte(0x0a);
+		break;
 	case "SMI":
 		assemblySkip(0x30);
 		break;
@@ -2595,6 +2604,9 @@ void assemblyInstruction(string instruction) {
 		break;
 	case "SPL":
 		assemblySkip(0x10);
+		break;
+	case "SRA":
+		putByte(0x4a);
 		break;
 	case "STA":
 		assemblyAccumulator(0x80, 0, 0);

--- a/source/app.d
+++ b/source/app.d
@@ -2659,19 +2659,24 @@ unittest {
 void assemblyPair() {
 	assert(!inOpcode);
 	string instruction = readInstruction();
-	if (!eol() && line[column] == ':') {
+	string[] extraInstructions;
+	while (!eol() && line[column] == ':') {
 		pairing = true;
 		column++;
-		string instruction2 = readInstruction();
+		extraInstructions ~= readInstruction();
+	}
+	if (!extraInstructions.empty) {
 		int savedColumn = column;
 		if (willSkip)
 			warning("Skipping only the first instruction");
 		assemblyInstruction(instruction);
 		checkNoExtraCharacters();
-		column = savedColumn;
 		wereManyInstructions = false;
-		assemblyInstruction(instruction2);
-		wereManyInstructions = true;
+		foreach (instruction2; extraInstructions) {
+			column = savedColumn;
+			assemblyInstruction(instruction2);
+			wereManyInstructions = true;
+		}
 	} else {
 		pairing = false;
 		assemblyInstruction(instruction);


### PR DESCRIPTION
Instruction pairing extended to more than 2 instructions was implemented first in hcasm and is available in MADS since 1.6.8.
I'm also adding argumentless variants of shifts and rotates, which are mostly useful in pairs or longer lists.

Submitting without docs first to just know your opinion whether it makes sense to have these in xasm.