### PR TITLE
Use older ldc because newer ones don't work on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+dist: bionic
 language: d
 d:
   - dmd
   - gdc
-  - ldc
+  - ldc-1.24.0


### PR DESCRIPTION
Seems like Travis uses Ubuntu xenial by default, which has libc version 2.23, but ldc2 expects 2.27.
Let's update to bionic which is the oldest one with 2.27 and see what happens.
