### PR TITLE
fixed space handling around inOpcode assembly lda #{lda #}

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -852,7 +852,7 @@ void readAddrMode() {
 	case '<':
 	case '>':
 		addrMode = AddrMode.IMMEDIATE;
-		if (inOpcode && line[column] == ' ' || line[column] == '\t')
+		if (inOpcode && (line[column] == ' ' || line[column] == '\t'))
 			readSpaces();
 		if (inOpcode && line[column] == '}')
 			return;

--- a/source/app.d
+++ b/source/app.d
@@ -594,6 +594,8 @@ void readValue() {
 			valOpStack.length = 0;
 			inOpcode = true;
 			assemblyInstruction(readInstruction());
+			if (line[column] == ' ' || line[column]=='\t' )
+				readSpaces();
 			if (readChar() != '}')
 				throw new AssemblyError("Missing '}'");
 			assert(!instructionBegin);
@@ -850,6 +852,8 @@ void readAddrMode() {
 	case '<':
 	case '>':
 		addrMode = AddrMode.IMMEDIATE;
+		if (inOpcode && line[column] == ' ' || line[column] == '\t')
+			readSpaces();
 		if (inOpcode && line[column] == '}')
 			return;
 		readWord();
@@ -2479,7 +2483,7 @@ void assemblyInstruction(string instruction) {
 		assemblyConditionalJump(0x50);
 		break;
 	case "LDA":
-		assemblyAccumulator(0xa0, 0, 0);
+		assemblyLda(0);
 		break;
 	case "LDX":
 		assemblyLdx(0);
@@ -2602,7 +2606,7 @@ void assemblyInstruction(string instruction) {
 		assemblySkip(0x10);
 		break;
 	case "STA":
-		assemblyAccumulator(0x80, 0, 0);
+		assemblySta(0);
 		break;
 	case "STX":
 		assemblyStx(0);

--- a/source/app.d
+++ b/source/app.d
@@ -593,6 +593,8 @@ void readValue() {
 			bool savedInstructionBegin = instructionBegin;
 			valOpStack.length = 0;
 			inOpcode = true;
+			if (line[column] == ' ' || line[column]=='\t' )
+				readSpaces();
 			assemblyInstruction(readInstruction());
 			if (line[column] == ' ' || line[column]=='\t' )
 				readSpaces();


### PR DESCRIPTION
Added space handling around this special case.
Now:
  lda #{lda # } 
  lda #{lda #0    }
  lda #{lda # 0 }
etc. assemble succesfuly instead of raising errors.